### PR TITLE
Use Olli ID to Hermes ID map to allow multi-site operation for testing

### DIFF
--- a/bestmile/.gitignore
+++ b/bestmile/.gitignore
@@ -1,1 +1,2 @@
 av-js-*.tgz
+av-js

--- a/bestmile/adapter.js
+++ b/bestmile/adapter.js
@@ -66,7 +66,7 @@ exports.process_trip_end_event = function(trip_end_event) {
     vehicles[vehicle_ids[0]].missionComplete(vehicle_ids[0])
 }
 
-exports.process_telemetry_transition = function(telemetry_transition) {
+exports.process_telemetry_transition = function(telemetry_transition, olliToHermesMap) {
     if(!telemetry_transition.transport_data || !telemetry_transition.transport_data.olli_vehicles){
         console.error(text_prefix, "Corrupted telemetry_transition received:", JSON.stringify(telemetry_transition, null, 2))
         return
@@ -74,7 +74,7 @@ exports.process_telemetry_transition = function(telemetry_transition) {
     const vehicles_telemetry = telemetry_transition.transport_data.olli_vehicles
     for (olli_name in vehicles_telemetry) {
         geo_position_event = vehicles_telemetry[olli_name]
-        geo_position_event.asset = olli_name; // set the vehicle ID in the 'asset' field
+        geo_position_event.asset = olliToHermesMap[olli_name] || olli_name; // set the vehicle ID in the 'asset' field
         process_geo_position_event(geo_position_event);
     }
 }

--- a/bestmile/app.js
+++ b/bestmile/app.js
@@ -15,7 +15,7 @@ const adapter = require('./adapter.js');
 
 const agent_name = config.get("agents.bestmile.name") || "bestmile"
 const module_name = config.get("agents.bestmile.module_name") || "bestmile";
-const vehicles = config.get("agents.bestmile.vehicle_ids") || [];
+const olliToHermesVehicleIDs = config.get("agents.bestmile.vehicle_ids") || [];
 const hermes = config.get("agents.bestmile.hermes_config") || null;
 // const hermes = { "host": "localhost", "port": "40000" }
 
@@ -26,7 +26,7 @@ debug("Agent name:", agent_name);
 
 // Start Adapter ----------------------------------------------
 
-adapter.start(vehicles, hermes)
+adapter.start(Object.values(olliToHermesVehicleIDs), hermes)
 
 // Follow database changes ----------------------------------------------
 
@@ -40,7 +40,7 @@ const feed = new follow.Feed({
     filter: (doc, req) => doc._id == "telemetry_transition"
 });
 
-feed.on('change', change => adapter.process_telemetry_transition(change.doc))
+feed.on('change', change => adapter.process_telemetry_transition(change.doc, olliToHermesVehicleIDs))
 
 feed.on('error', function(er) {
     console.error('Since Follow always retries on errors, this must be serious', er);

--- a/config/default.json
+++ b/config/default.json
@@ -78,9 +78,11 @@
         "bestmile" : {
             "module_name" : "bestmile",
             "name": "bestmile",
-            "vehicle_ids": ["olli_1",
-                            "olli_2",
-                            "olli_3"],
+            "vehicle_ids": {
+              "olli_1": "olli_1",
+              "olli_2": "olli_2",
+              "olli_3": "olli_3"
+            },
             "hermes_config": { "host": "accessibleolli.env.partners.bestmile.io", "port": "32363" }
         }
     },


### PR DESCRIPTION
This change allows to define which olli roller corresponds to which one on BestMile side. 
In config JSON, use `"olli_x": "olli_x"` for production, but use `"olli_x": "olli_yx"` to use telemetry data of `olli_x` on test environment `Rochester Y`.

Changes are backward-compatible